### PR TITLE
Header doc comment

### DIFF
--- a/scripts/1_room_limit.coffee
+++ b/scripts/1_room_limit.coffee
@@ -1,3 +1,6 @@
+# Description:
+#   Prevents The God to say something in general channel
+
 module.exports = (robot) ->
   robot.hear /.*/, (msg) ->
     if msg.envelope.room in ['general']

--- a/scripts/god.coffee
+++ b/scripts/god.coffee
@@ -1,12 +1,5 @@
 # Description:
-#   Example scripts for you to examine and try out.
-#
-# Notes:
-#   They are commented out by default, because most of them are pretty silly and
-#   wouldn't be useful and amusing enough for day to day huboting.
-#   Uncomment the ones you want to try and experiment with.
-#
-#   These are from the scripting documentation: https://github.com/github/hubot/blob/master/docs/scripting.md
+#   The God script.
 
 GodIkemen = require '../lib/god_ikemen'
 GodPhoto  = require '../lib/god_photo'


### PR DESCRIPTION
- ファイル先頭のコメントを生成時のものから変更
- `1_room_limit`にコメントを付け、CLI起動時の警告を抑制
