### PR TITLE
IBM Bluemixにデプロイするためのマニフェストファイルを追加する

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+applications:
+- buildpack: https://github.com/jthomas/nodejs-v4-buildpack.git
+  command: ./bin/hubot -a slack -n chi-bot
+  path: .
+  instances: 1
+  memory: 256M


### PR DESCRIPTION
@Joe-noh 

[IBM Bluemix](https://console.ng.bluemix.net/) を使ってみたくなったので、そのために必要なマニフェストファイルを追加します :cat: 
